### PR TITLE
Resolves failure while building with the --img option when parted is not...

### DIFF
--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -151,13 +151,14 @@ detect_software () {
 
 	if [ "${build_img_file}" ] ; then
 		check_for_command kpartx kpartx
+		check_for_command partprobe parted
 	fi
 
 	if [ "${NEEDS_COMMAND}" ] ; then
 		echo ""
 		echo "Your system is missing some dependencies"
 		echo "Angstrom: opkg install dosfstools git util-linux wget"
-		echo "Debian/Ubuntu: sudo apt-get install dosfstools git-core kpartx u-boot-tools wget"
+		echo "Debian/Ubuntu: sudo apt-get install dosfstools git-core kpartx u-boot-tools wget parted"
 		echo "Fedora: yum install dosfstools dosfstools git-core uboot-tools wget"
 		echo "Gentoo: emerge dosfstools git u-boot-tools wget"
 		echo ""


### PR DESCRIPTION
I'm not sure if partprobe is used for non-img file builds, but it failed for me without checking this dependency.
