### PR TITLE
(Urgent) Use HTTPS instead of HTTP when sites have valid mainstream certs

### DIFF
--- a/beagleboard.org_image.sh
+++ b/beagleboard.org_image.sh
@@ -81,7 +81,7 @@ minimal_armel () {
 	#Actual Releases will use version numbers..
 	case "${deb_codename}" in
 	wheezy)
-		#http://www.debian.org/releases/wheezy/
+		#https://www.debian.org/releases/wheezy/
 		export_filename="${deb_distribution}-${wheezy_release}-${image_type}-${deb_arch}-${time}"
 		;;
 	quantal)

--- a/eewiki_barefs_image.sh
+++ b/eewiki_barefs_image.sh
@@ -39,7 +39,7 @@ minimal_armel () {
 	#Actual Releases will use version numbers..
 	case "${deb_codename}" in
 	wheezy)
-		#http://www.debian.org/releases/wheezy/
+		#https://www.debian.org/releases/wheezy/
 		export_filename="${deb_distribution}-${wheezy_release}-${image_type}-${deb_arch}-${time}"
 		;;
 	quantal)

--- a/eewiki_base_image.sh
+++ b/eewiki_base_image.sh
@@ -39,7 +39,7 @@ minimal_armel () {
 	#Actual Releases will use version numbers..
 	case "${deb_codename}" in
 	wheezy)
-		#http://www.debian.org/releases/wheezy/
+		#https://www.debian.org/releases/wheezy/
 		export_filename="${deb_distribution}-${wheezy_release}-${image_type}-${deb_arch}-${time}"
 		;;
 	quantal)

--- a/host/rcn-ee-host.sh
+++ b/host/rcn-ee-host.sh
@@ -2,7 +2,7 @@
 
 system=$(uname -n)
 
-mirror="http://rcn-ee.net/deb"
+mirror="https://rcn-ee.net/deb"
 case "${system}" in
 poseidon)
 	mirror="http://rcn-ee.homeip.net:81/dl/mirrors/deb"

--- a/rcn-ee_image.sh
+++ b/rcn-ee_image.sh
@@ -43,7 +43,7 @@ minimal_armel () {
 	#Actual Releases will use version numbers..
 	case "${deb_codename}" in
 	wheezy)
-		#http://www.debian.org/releases/wheezy/
+		#https://www.debian.org/releases/wheezy/
 		export_filename="${deb_distribution}-${wheezy_release}-${image_type}-${deb_arch}-${time}"
 		;;
 	quantal)

--- a/rcn-ee_test_image.sh
+++ b/rcn-ee_test_image.sh
@@ -43,7 +43,7 @@ minimal_armel () {
 	#Actual Releases will use version numbers..
 	case "${deb_codename}" in
 	wheezy)
-		#http://www.debian.org/releases/wheezy/
+		#https://www.debian.org/releases/wheezy/
 		export_filename="${deb_distribution}-${wheezy_release}-${image_type}-${deb_arch}-${time}"
 		;;
 	quantal)

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -51,7 +51,7 @@ debootstrap_what_version
 
 if [[ "$test_debootstrap" < "$minimal_debootstrap" ]] ; then
 	echo "Log: Installing minimal debootstrap version: 1.0."${minimal_debootstrap}"..."
-	wget http://rcn-ee.net/mirror/debootstrap/debootstrap_1.0.${minimal_debootstrap}_all.deb
+	wget https://rcn-ee.net/mirror/debootstrap/debootstrap_1.0.${minimal_debootstrap}_all.deb
 	sudo dpkg -i debootstrap_1.0.${minimal_debootstrap}_all.deb
 	rm -rf debootstrap_1.0.${minimal_debootstrap}_all.deb || true
 fi

--- a/target/chroot/beagleboard.org.sh
+++ b/target/chroot/beagleboard.org.sh
@@ -241,7 +241,7 @@ install_node_pkgs () {
 
 		cd /opt/
 		mkdir -p /opt/cloud9/
-		wget http://rcn-ee.net/pkgs/c9v3/c9v3-6280b336-standalonebuild-systemd.tgz
+		wget https://rcn-ee.net/pkgs/c9v3/c9v3-6280b336-standalonebuild-systemd.tgz
 		if [ -f /opt/c9v3-6280b336-standalonebuild-systemd.tgz ] ; then
 			tar xf c9v3-6280b336-standalonebuild-systemd.tgz -C /opt/cloud9/
 			rm -rf c9v3-6280b336-standalonebuild-systemd.tgz || true
@@ -254,7 +254,7 @@ install_node_pkgs () {
 			fi
 		fi
 
-		git_repo="http://github.com/beagleboard/bone101"
+		git_repo="https://github.com/beagleboard/bone101"
 		git_target_dir="/var/lib/cloud9"
 		git_clone
 		if [ -f ${git_target_dir}/.git/config ] ; then
@@ -393,11 +393,11 @@ install_git_repos () {
 
 install_build_pkgs () {
 	cd /opt/
-	wget http://rcn-ee.net/pkgs/chromium/${chromium_release}-armhf.tar.xz
+	wget https://rcn-ee.net/pkgs/chromium/${chromium_release}-armhf.tar.xz
 	if [ -f /opt/${chromium_release}-armhf.tar.xz ] ; then
 		tar xf ${chromium_release}-armhf.tar.xz -C /
 		rm -rf ${chromium_release}-armhf.tar.xz || true
-		echo "${chromium_release} : http://rcn-ee.net/pkgs/chromium/${chromium_release}.tar.xz" >> /opt/source/list.txt
+		echo "${chromium_release} : https://rcn-ee.net/pkgs/chromium/${chromium_release}.tar.xz" >> /opt/source/list.txt
 
 		#link Chromium to /usr/bin/x-www-browser
 		update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/chromium 200
@@ -413,7 +413,7 @@ other_source_links () {
 
 	echo "MT7601: /etc/Wireless/RT2870/RT2870STA.dat" >> /opt/source/list.txt
 	echo "MT7601: MODULES/kernel/drivers/net/wireless/mt7601Usta.ko" >> /opt/source/list.txt
-	echo "MT7601: http://rcn-ee.net/deb/thirdparty/MT7601/DPO_MT7601U_LinuxSTA_3.0.0.4_20130913.tar.bz2" >> /opt/source/list.txt
+	echo "MT7601: https://rcn-ee.net/deb/thirdparty/MT7601/DPO_MT7601U_LinuxSTA_3.0.0.4_20130913.tar.bz2" >> /opt/source/list.txt
 }
 
 unsecure_root () {

--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -22,13 +22,10 @@
 # THE SOFTWARE.
 #
 # Latest can be found at:
-# http://github.com/RobertCNelson/omap-image-builder/blob/master/tools/setup_sdcard.sh
+# https://github.com/RobertCNelson/omap-image-builder/blob/master/tools/setup_sdcard.sh
 
 #REQUIREMENTS:
 #uEnv.txt bootscript support
-
-MIRROR="http://rcn-ee.net/deb"
-BACKUP_MIRROR="http://rcn-ee.homeip.net:81/dl/mirrors/deb"
 
 BOOT_LABEL="boot"
 
@@ -1278,7 +1275,7 @@ is_omap () {
 
 check_uboot_type () {
 	#New defines for hwpack:
-	conf_bl_http="http://rcn-ee.net/deb/tools/latest"
+	conf_bl_http="https://rcn-ee.net/deb/tools/latest"
 	conf_bl_listfile="bootloader-ng"
 
 	unset IN_VALID_UBOOT


### PR DESCRIPTION
(Make the build more resistant against MITM attacks, part #1)

http://rcn-ee.net -> https://rcn-ee.net
http://github.com -> https://github.com
http://www.debian.org -> https://www.debian.org

This patch also applies to https://github.com/beagleboard/image-builder - should I submit a separate pull request for that?
