### PR TITLE
fixed a failed check for MMC device when re-flashing a BBB

### DIFF
--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -1119,7 +1119,7 @@ populate_rootfs () {
 }
 
 check_mmc () {
-	FDISK=$(LC_ALL=C fdisk -l 2>/dev/null | grep "Disk ${media}" | awk '{print $2}')
+	FDISK=$(LC_ALL=C fdisk -l 2>/dev/null | grep "Disk ${media}:" | awk '{print $2}')
 
 	if [ "x${FDISK}" = "x${media}:" ] ; then
 		echo ""


### PR DESCRIPTION
This check failed on a BBB I had that had previously been flashed with Ubuntu 13.04 to its MMC. Here was what the grep returned before my change:

```
/dev/mmcblk1:
/dev/mmcblk1boot1:
/dev/mmcblk1boot0:
```

This obviously failed the check to see if the grep results matched the provided MMC device.
