### PR TITLE
chroot: add option to prevent removal of ssh keys

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -861,7 +861,7 @@ echo "${rfs_username}:${rfs_password}" > /tmp/user_password.list
 sudo mv /tmp/user_password.list ${DIR}/deploy/${export_filename}/user_password.list
 
 #Fixes:
-if [ -d ${tempdir}/etc/ssh/ ] ; then
+if [ -d ${tempdir}/etc/ssh/ -a "x${keep_ssh_keys}" = "x" ] ; then
 	#Remove pre-generated ssh keys, these will be regenerated on first bootup...
 	sudo rm -rf ${tempdir}/etc/ssh/ssh_host_* || true
 	sudo touch ${tempdir}/etc/ssh/ssh.regenerate || true


### PR DESCRIPTION
I've added an option to prevent removal of the ssh keys in `chroot.sh`.  I'd like to be able to mount the resulting filesystem read-only and if the keys are removed and the filesystem is read-only, they cannot be regenerated on boot.
