### PR TITLE
update chroot script invocations to always exit on error

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -791,8 +791,8 @@ if [ "x${include_firmware}" = "xenable" ] ; then
 fi
 
 chroot_mount
-sudo chroot ${tempdir} /bin/sh chroot_script.sh
-echo "Log: Complete: [sudo chroot ${tempdir} /bin/sh chroot_script.sh]"
+sudo chroot ${tempdir} /bin/sh -e chroot_script.sh
+echo "Log: Complete: [sudo chroot ${tempdir} /bin/sh -e chroot_script.sh]"
 
 if [ ! "x${rfs_opt_scripts}" = "x" ] ; then
 	if [ ! -f ${tempdir}/opt/scripts/.git/config ] ; then
@@ -813,7 +813,7 @@ if [ -n "${chroot_script}" -a -r "${DIR}/target/chroot/${chroot_script}" ] ; the
 	echo "Calling chroot_script script: ${chroot_script}"
 	sudo cp -v ${DIR}/.project ${tempdir}/etc/oib.project
 	sudo cp -v ${DIR}/target/chroot/${chroot_script} ${tempdir}/final.sh
-	sudo chroot ${tempdir} /bin/sh final.sh
+	sudo chroot ${tempdir} /bin/sh -e final.sh
 	sudo rm -f ${tempdir}/final.sh || true
 	sudo rm -f ${tempdir}/etc/oib.project || true
 	chroot_script=""


### PR DESCRIPTION
The shebangs at the top of the chroot scripts specify the -e option however when passing the scripts to /bin/sh directly, the -e option is no longer honored.  I think it is useful to have the entire process exit if any contained operations fail.
