### PR TITLE
Making .project file available in early_chroot_script.

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -806,8 +806,10 @@ fi
 if [ -n "${early_chroot_script}" -a -r "${DIR}/target/chroot/${early_chroot_script}" ] ; then
 	report_size
 	echo "Calling early_chroot_script script: ${early_chroot_script}"
+	sudo cp -v ${DIR}/.project ${tempdir}/etc/oib.project
 	sudo /bin/sh -e ${DIR}/target/chroot/${early_chroot_script} ${tempdir}
 	early_chroot_script=""
+	sudo rm -f ${tempdir}/etc/oib.project || true
 fi
 
 chroot_mount


### PR DESCRIPTION
The user can source ${tempdir}/etc/oib.project to access the project env variables like username, hostname and so on in early_chroot_script.
