### PR TITLE
add exit trap to ensure that chroot filesystem is unmounted

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -192,6 +192,8 @@ chroot_umount () {
 	fi
 }
 
+trap chroot_umount EXIT
+
 check_defines
 
 if [ "x${host_arch}" != "xarmv7l" ] ; then


### PR DESCRIPTION
If the image building process fails (occasional timeout reaching package repositories, etc.) after the chroot filesystem has been mounted, then the mounts stay intact after the script exits.  It is not possible to delete the temp directory at this point without explicitly unmounting the chroot mounts.  Adding a trap ensures that this cleanup is performed if the script exits from an error condition.