### PR TITLE
remove quotes from list passed to apt-get install

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -39,7 +39,7 @@ debootstrap_is_installed () {
 	if [ "${deb_pkgs}" ] ; then
 		echo "Installing: ${deb_pkgs}"
 		sudo apt-get update
-		sudo apt-get -y install "${deb_pkgs}"
+		sudo apt-get -y install ${deb_pkgs}
 	fi
 }
 


### PR DESCRIPTION
With the quotes in place, apt-get looks for a package matching the contents of the quoted string and fails with message: ```E: Unable to locate package debootstrap``` (has trailing space). Removing the quotes resolves the issue.