### PR TITLE
Mix HWRNG to the kernel before generating ssh keys.

### DIFF
--- a/target/init_scripts/generic-debian.sh
+++ b/target/init_scripts/generic-debian.sh
@@ -41,6 +41,8 @@ start|reload|force-reload|restart)
 	#Regenerate ssh host keys
 	if [ -f /etc/ssh/ssh.regenerate ] ; then
 		rm -rf /etc/ssh/ssh_host_* || true
+		# Mix in the output of the HWRNG to the kernel before generating ssh keys
+		dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 2>/dev/null
 		dpkg-reconfigure openssh-server
 		sync
 		if [ -s /etc/ssh/ssh_host_ecdsa_key.pub ] ; then


### PR DESCRIPTION
This issue is mainly motivated by a RPi issue documented [here](https://github.com/RPi-Distro/repo/issues/6) and [here](https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=1268920).

There are some very strong opinions in those posts. I recommend merging this pull request based on the following observations/comments:

1. The BBB since 3.8 has had support for HWRNG
2. We want to regenerate unique keys for sshd on init. 
3. It appears openssh pulls from /dev/urandom
4. The state of entropy in the BBB is probably low at this point as, as far as I understand the linux kernel's random implementation, even if you have a /dev/hwrng it's not explicitly used by the random pool.

Therefore, I think this will improve the state of the internal random number generator.

Note: This will *not* change the entropy_available value, as that is controlled by a different mechanism. Writing to /dev/urandom goes [here](http://lxr.free-electrons.com/source/drivers/char/random.c#L1586) which causes mixing of the RNG.
