### PR TITLE
do not change ownership when leaving filesystem in directory

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -1209,10 +1209,10 @@ else
 	sudo LANG=C tar --numeric-owner -cf "${DIR}/deploy/${export_filename}/${deb_arch}-rootfs-${deb_distribution}-${deb_codename}.tar" .
 	cd "${DIR}/" || true
 	ls -lh "${DIR}/deploy/${export_filename}/${deb_arch}-rootfs-${deb_distribution}-${deb_codename}.tar"
+	sudo chown -R ${USER}:${USER} "${DIR}/deploy/${export_filename}/"
 fi
 
 echo "Log: USER:${USER}"
-sudo chown -R ${USER}:${USER} "${DIR}/deploy/${export_filename}/"
 
 if [ "x${chroot_tarball}" = "xenable" ] ; then
 	echo "Creating: ${export_filename}.tar"


### PR DESCRIPTION
Changing ownership of the filesystem contents (as is the case when using the ```chroot_directory``` option) causes issues (some files require certain ownership, users should retain ownership of their home directories, etc.).