### PR TITLE
fix fixing the ping command

### DIFF
--- a/target/chroot/beagleboard.org-console-jessie.sh
+++ b/target/chroot/beagleboard.org-console-jessie.sh
@@ -179,9 +179,19 @@ setup_desktop () {
 	#fix Ping:
 	#ping: icmp open socket: Operation not permitted
 	if [ -f /bin/ping ] ; then
-		chmod u+x /bin/ping
+	    if command -v setcap > /dev/null; then
+		if setcap cap_net_raw+ep /bin/ping cap_net_raw+ep /bin/ping6; then
+		    echo "Setcap worked! Ping(6) is not suid!"
+		else
+		    echo "Setcap failed on /bin/ping, falling back to setuid" >&2
+		    chmod u+s /bin/ping /bin/ping6
+		fi
+	    else
+		echo "Setcap is not installed, falling back to setuid" >&2
+		chmod u+s /bin/ping /bin/ping6
+	    fi
 	fi
-
+	
 	if [ -f /etc/init.d/connman ] ; then
 		mkdir -p /etc/connman/ || true
 		wfile="/etc/connman/main.conf"

--- a/target/chroot/beagleboard.org-jessie.sh
+++ b/target/chroot/beagleboard.org-jessie.sh
@@ -179,7 +179,17 @@ setup_desktop () {
 	#fix Ping:
 	#ping: icmp open socket: Operation not permitted
 	if [ -f /bin/ping ] ; then
-		chmod u+x /bin/ping
+	    if command -v setcap > /dev/null; then
+		if setcap cap_net_raw+ep /bin/ping cap_net_raw+ep /bin/ping6; then
+		    echo "Setcap worked! Ping(6) is not suid!"
+		else
+		    echo "Setcap failed on /bin/ping, falling back to setuid" >&2
+		    chmod u+s /bin/ping /bin/ping6
+		fi
+	    else
+		echo "Setcap is not installed, falling back to setuid" >&2
+		chmod u+s /bin/ping /bin/ping6
+	    fi
 	fi
 
 	if [ -f /etc/init.d/connman ] ; then

--- a/target/chroot/seeed-jessie.sh
+++ b/target/chroot/seeed-jessie.sh
@@ -179,7 +179,17 @@ setup_desktop () {
 	#fix Ping:
 	#ping: icmp open socket: Operation not permitted
 	if [ -f /bin/ping ] ; then
-		chmod u+x /bin/ping
+	    if command -v setcap > /dev/null; then
+		if setcap cap_net_raw+ep /bin/ping cap_net_raw+ep /bin/ping6; then
+		    echo "Setcap worked! Ping(6) is not suid!"
+		else
+		    echo "Setcap failed on /bin/ping, falling back to setuid" >&2
+		    chmod u+s /bin/ping /bin/ping6
+		fi
+	    else
+		echo "Setcap is not installed, falling back to setuid" >&2
+		chmod u+s /bin/ping /bin/ping6
+	    fi
 	fi
 
 	if [ -f /etc/init.d/connman ] ; then


### PR DESCRIPTION
debian tar is too stupid to save and restore extended attributes, even if given `--xattrs --acls --selinux` 

installing iputils-ping does the right thing and does a setpcap on those file systems which support it
`````
root@beaglebone:/bin# sudo apt-get install iputils-ping --reinstall
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  liblockfile-bin liblockfile1 lockfile-progs
Use 'apt-get autoremove' to remove them.
0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 0 not upgraded.
Need to get 53.7 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://httpredir.debian.org/debian/ jessie/main iputils-ping armhf 3:20121221-5+b2 [53.7 kB]
Fetched 53.7 kB in 0s (165 kB/s)  
(Reading database ... 70748 files and directories currently installed.)
Preparing to unpack .../iputils-ping_3%3a20121221-5+b2_armhf.deb ...
Unpacking iputils-ping (3:20121221-5+b2) over (3:20121221-5+b2) ...
Processing triggers for man-db (2.7.0.2-5) ...
Setting up iputils-ping (3:20121221-5+b2) ...
Setcap worked! Ping(6) is not suid!
root@beaglebone:/bin# 
`````
the reason why the caps dont make it into the final file system is likely tar:
`````
root@beaglebone:/bin# getcap ping
ping = cap_net_raw+ep        <--- as per dpkg 
root@beaglebone:/bin# tar cvf /tmp/XXX ping
ping
root@beaglebone:/bin# cd /tmp/
root@beaglebone:/tmp# tar xvf XXX
ping
root@beaglebone:/tmp# getcap ping 
root@beaglebone:/tmp#           <-------- nada

root@beaglebone:/tmp# tar --version
tar (GNU tar) 1.27.1
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
 
Written by John Gilmore and Jay Fenlason.
`````


hence it's not an issue which can be fixed by chmod u+x 
solution:  clone parts of the iputils-ping postinstall script 
see also https://lists.uni-koeln.de/pipermail/linux-fai/2014-May/010395.html


for the full uglinesss on support of extended attributes: http://www.lesbonscomptes.com/pages/extattrs.html