### PR TITLE
support Ubuntu's bootstrap version string

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -44,7 +44,7 @@ debootstrap_is_installed () {
 }
 
 debootstrap_what_version () {
-	test_debootstrap=$(/usr/sbin/debootstrap --version | cut -f3 -d.)
+	test_debootstrap=$(/usr/sbin/debootstrap --version | cut -f3 -d. | grep -o '^[0-9.]\+')
 	echo "Log: debootstrap version: 1.0.$test_debootstrap"
 }
 


### PR DESCRIPTION
bootstrap version strings like "debootstrap 1.0.67ubuntu0.2" before would generate the error: "/home/nuno/omap-image-builder/scripts/install_dependencies.sh: line 55: [: 67ubuntu0: integer expression expected"