### PR TITLE
Machinekit: Add uuid-runtime package

### DIFF
--- a/configs/machinekit-debian-jessie.conf
+++ b/configs/machinekit-debian-jessie.conf
@@ -59,6 +59,7 @@ deb_include="	\
 	udhcpd	\
 	usb-modeswitch	\
 	usbutils	\
+	uuid-runtime	\
 	vim	\
 	wget	\
 	wireless-tools	\

--- a/configs/machinekit-debian-wheezy.conf
+++ b/configs/machinekit-debian-wheezy.conf
@@ -100,6 +100,7 @@ deb_additional_pkgs="	\
 	udhcpd	\
 	usb-modeswitch	\
 	usbutils	\
+	uuid-runtime	\
 	vim	\
 	wicd-cli	\
 	wicd-curses	\


### PR DESCRIPTION
Add uuid-runtime package required to generate new MKUUID values
for Machinetalk remote UIs.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>