### PR TITLE
Fix missing conditional in `create_partitions`

### DIFF
--- a/tools/setup_sdcard.sh
+++ b/tools/setup_sdcard.sh
@@ -633,7 +633,7 @@ create_partitions () {
 
 	unset ext4_options
 
-	if [ ! "x${uboot_supports_csum}" = "xtrue" ]
+	if [ ! "x${uboot_supports_csum}" = "xtrue" ] ; then
 		#Debian Stretch, mfks.ext4 default to metadata_csum, 64bit disable till u-boot works again..
 		unset ext4_options
 		unset test_mke2fs


### PR DESCRIPTION
`./setup_sdcard.sh: line 647: syntax error near unexpected token `fi' 

is generated unless missing `then` is added back in.