### PR TITLE
chroot.sh: Clean out /tmp

### DIFF
--- a/scripts/chroot.sh
+++ b/scripts/chroot.sh
@@ -1192,6 +1192,9 @@ cat > "${DIR}/cleanup_script.sh" <<-__EOF__
 #		if [ -d /run/ ] ; then
 #			rm -rf /run/* || true
 #		fi
+
+		# Clear out the /tmp directory
+		rm -rf /tmp/* || true
 	}
 
 	cleanup


### PR DESCRIPTION
Delete any files in the chroot /tmp/ directory before exiting.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>