### PR TITLE
RootStock.ng: Fix sourcing via m4

### DIFF
--- a/RootStock-NG.sh
+++ b/RootStock-NG.sh
@@ -106,7 +106,7 @@ check_project_config () {
 	#${project_config}.conf
 	project_config=$(echo ${project_config} | awk -F ".conf" '{print $1}')
 	if [ -f ${DIR}/configs/${project_config}.conf ] ; then
-		m4 -P ${DIR}/configs/${project_config}.conf | . /dev/fd/0
+		. <(m4 -P ${DIR}/configs/${project_config}.conf)
 		export_filename="${deb_distribution}-${release}-${image_type}-${deb_arch}-${time}"
 
 		# for automation


### PR DESCRIPTION
Use process substitution so variables modified by sourcing the conf
file are seen in the main shell

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>