### PR TITLE
Add fsprotect to the list of included packages

### DIFF
--- a/configs/bb.org-debian-buster-iot-v4.14.conf
+++ b/configs/bb.org-debian-buster-iot-v4.14.conf
@@ -37,6 +37,7 @@ deb_include="	\
 	firmware-realtek	\
 	firmware-ti-connectivity	\
 	firmware-zd1211	\
+	fsprotect	\
 	git	\
 	gnupg	\
 	haveged	\


### PR DESCRIPTION
(This change is more of a proposal than a proper, full change.)

Adding https://packages.debian.org/buster/fsprotect might make it easier to configure Beagles as components in appliances where the power might be cut unexpectedly---before the user can initiate a clean shutdown.

As an example, I'd like to be able to set up https://github.com/stepleton/cameo/tree/master/aphid so that it can emulate an internal hard drive, but the PocketBeagle's power button is inaccessible when the Beagle is installed inside a computer's case. When the computer shuts off, power to the PocketBeagle is cut off as well, without warning.

If I could protect most of the Beagle's filesystem with fsprotect, then as long as my own software took care of flushing writes to the hard drive emulator's disk image, I wouldn't have to worry about filesystem components being damaged during power loss.

This seems like a useful facility for Beagles in general, which seem ideally suited to applications where they are embedded within other, larger systems.