### PR TITLE
forcing the hexchat-common version for installs

### DIFF
--- a/configs/ren-debian-sid-budgie-riscv64.conf
+++ b/configs/ren-debian-sid-budgie-riscv64.conf
@@ -321,6 +321,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\

--- a/configs/ren-debian-sid-cinnamon-riscv64.conf
+++ b/configs/ren-debian-sid-cinnamon-riscv64.conf
@@ -297,6 +297,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\

--- a/configs/ren-debian-sid-lxde-riscv64.conf
+++ b/configs/ren-debian-sid-lxde-riscv64.conf
@@ -321,6 +321,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\

--- a/configs/ren-debian-sid-lxqt-riscv64.conf
+++ b/configs/ren-debian-sid-lxqt-riscv64.conf
@@ -329,6 +329,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\

--- a/configs/ren-debian-sid-mate-riscv64.conf
+++ b/configs/ren-debian-sid-mate-riscv64.conf
@@ -328,6 +328,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\

--- a/configs/ren-debian-sid-xfce-riscv64.conf
+++ b/configs/ren-debian-sid-xfce-riscv64.conf
@@ -330,6 +330,7 @@ deb_desktop_application_pkgs="	\
 	filezilla	\
 	geany	\
 	gimp	\
+	hexchat-common=2.14.3-6	\
 	hexchat	\
 	meld	\
 	mpv	\


### PR DESCRIPTION
hexchat installs broken in repo reporting wrong version . set hexchat-common to proper version