### PR TITLE
figured out what packages failed to install and made necessary changes

### DIFF
--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -81,6 +81,9 @@ deb_mirror=""
 ##Some packages fail to install via debootstrap: deb_additional_pkgs="<comma|space>"
 ##
 deb_additional_pkgs="	\
+	clang-3.9	\
+	gdb	\
+	git-core	\
 	net-tools	\
 "
 

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -33,7 +33,6 @@ deb_include="	\
 	firmware-realtek	\
 	firmware-ti-connectivity	\
 	flex	\
-	gdb	\
 	git	\
 	glibc-doc	\
 	hostapd	\

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -51,6 +51,7 @@ deb_include="	\
 	libreadline-dev	\
 	libsndfile1-dev	\
 	libssl-dev	\
+	libstdc++6-10-dbg	\
 	libtool	\
 	libtool-bin	\
 	libx11-dev	\

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -45,6 +45,7 @@ deb_include="	\
 	libfftw3-dev	\
 	liblo-dev	\
 	libltdl-dev	\
+	libmicrohttpd-dev	\
 	libncurses5-dev	\
 	libnss-mdns	\
 	libreadline-dev	\
@@ -56,6 +57,7 @@ deb_include="	\
 	locales	\
 	man-db	\
 	manpages-dev	\
+	nodejs	\
 	openssh-server	\
 	psmisc	\
 	rsync	\

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -61,6 +61,12 @@ deb_include="	\
 	nodejs	\
 	openssh-server	\
 	psmisc	\
+	python3-dev	\
+	python3-flufl.enum	\
+	python3-jinja2	\
+	python3-pip	\
+	python3-setuptools	\
+	python3-wheel	\
 	rsync	\
 	screen	\
 	strace	\


### PR DESCRIPTION
- moved packages (clang-3.9, gdb, git-core) that fail to install via debootstrap and added in deb_addition_pkgs
- added libmicrohttpd-dev, nodejs pkgs
- added libstdc++6-10-dbg that match with libstdc++ version on the board
- added python3-pip, wheel, enum,jinja2 and adjust python pkgs with python3 in bullseye python2 is DEPRECATED
