### PR TITLE
modify bela-bullseye chroot script

### DIFF
--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -135,11 +135,23 @@ install_git_repos () {
     git_target_dir="/opt/source/am335x_pru_package"
     git_branch="master"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building PRU utils ~~~~"
+        make -j${CORES}
+        make install
+	fi
 
     git_repo="https://github.com/giuliomoro/prudebug.git"
     git_target_dir="/opt/source/prudebug"
     git_branch="master"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building prudebug ~~~~"
+        make -j${CORES}
+        cp -v ./prudebug /usr/bin/
+	fi
 
 
     git_repo="https://github.com/giuliomoro/Bootloader-Builder.git"
@@ -152,24 +164,63 @@ install_git_repos () {
     git_target_dir="/opt/source/bb.org-overlays"
     git_branch="master"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building bb.org-overlays ~~~~"
+        make clean
+        make -j${CORES}
+        make install
+        cp -v ./tools/beaglebone-universal-io/config-pin /usr/local/bin/
+        make clean
+	fi
 
 
     git_repo="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/ "
     git_target_dir="/opt/source/bb.org-dtc"
     git_branch="v1.6.0"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building bb.org-dtc ~~~~"
+        make clean
+        make -j${CORES} PREFIX=/usr/local CC=gcc CROSS_COMPILE= all
+        make PREFIX=/usr/local/ install
+        ln -sf /usr/local/bin/dtc /usr/bin/dtc
+        echo "dtc: `/usr/bin/dtc --version`"
+        make clean
+	fi
 
 
     git_repo="https://github.com/RobertCNelson/dtb-rebuilder.git"
     git_target_dir="/opt/source/dtb-rebuilder"
     git_branch="4.14-ti"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building Bela dtb ~~~~"
+        make clean
+        make -j${CORES}
+        make install
+        make clean
+	fi
 
 
     git_repo="https://github.com/mattgodbolt/seasocks.git"
     git_target_dir="/opt/source/seasocks"
     git_branch="v1.4.4"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building Seasocks ~~~~"
+        mkdir build
+        cd build
+        cmake .. -DDEFLATE_SUPPORT=OFF -DUNITTESTS=OFF -DSEASOCKS_SHARED=ON
+        make -j${CORES} seasocks
+        /usr/bin/cmake -P cmake_install.cmake
+        cd /root
+        rm -rf /opt/seasocks/build
+        ldconfig
+	fi
 
 
     git_repo="https://github.com/BelaPlatform/rtdm_pruss_irq"
@@ -181,7 +232,7 @@ install_git_repos () {
     git_repo="https://github.com/giuliomoro/checkinstall"
     git_target_dir="/opt/source/checkinstall"
     git_branch="master"
-        git_clone_branch
+    git_clone_branch
 
 
     git_repo="https://github.com/giuliomoro/hvcc"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -124,6 +124,13 @@ install_git_repos () {
     git_target_dir="/opt/source/xenomai-3"
     git_branch="stable/v3.0.x"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+        echo "~~~~ cross-compiling xenomai  ~~~~"
+    	scripts/bootstrap
+    	./configure --with-core=cobalt --enable-smp --host=arm-linux-gnueabihf --build=arm CFLAGS="-march=armv7-a -mfpu=vfp3"
+	    make -j${CORES}
+	fi
 
 
     git_repo="https://github.com/BelaPlatform/Bela.git"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -88,22 +88,6 @@ setup_system () {
 }
 
 install_git_repos () {
-	if [ -f /usr/bin/make ] ; then
-		echo "Installing pip packages"
-		git_repo="https://github.com/adafruit/adafruit-beaglebone-io-python.git"
-		git_target_dir="/opt/source/adafruit-beaglebone-io-python"
-		git_clone
-		if [ -f ${git_target_dir}/.git/config ] ; then
-			cd ${git_target_dir}/
-			sed -i -e 's:4.1.0:3.4.0:g' setup.py || true
-			sed -i -e "s/strict-aliasing/strict-aliasing', '-Wno-cast-function-type', '-Wno-format-truncation', '-Wno-sizeof-pointer-memaccess', '-Wno-stringop-overflow/g" setup.py || true
-			if [ -f /usr/bin/python3 ] ; then
-				python3 setup.py install || true
-			fi
-			git reset HEAD --hard || true
-		fi
-	fi
-
 	git_repo="https://github.com/beagleboard/BeagleBoard-DeviceTrees"
 	git_target_dir="/opt/source/dtb-5.4-ti"
 	git_branch="v5.4.x-ti-overlays"
@@ -119,7 +103,6 @@ install_git_repos () {
     git_branch="ti-linux-xenomai-4.14.y"
     git_clone_branch
 
-
     git_repo="git://git.xenomai.org/xenomai-3.git"
     git_target_dir="/opt/source/xenomai-3"
     git_branch="stable/v3.0.x"
@@ -131,7 +114,6 @@ install_git_repos () {
     	./configure --with-core=cobalt --enable-smp --host=arm-linux-gnueabihf --build=arm CFLAGS="-march=armv7-a -mfpu=vfp3"
 	    make -j${CORES}
 	fi
-
 
     git_repo="https://github.com/BelaPlatform/Bela.git"
     git_target_dir="/opt/source/Bela"
@@ -160,12 +142,10 @@ install_git_repos () {
         cp -v ./prudebug /usr/bin/
 	fi
 
-
     git_repo="https://github.com/giuliomoro/Bootloader-Builder.git"
     git_target_dir="/opt/source/Bootloader-Builder"
     git_branch="master"
     git_clone_branch
-
 
     git_repo="https://github.com/BelaPlatform/bb.org-overlays.git"
     git_target_dir="/opt/source/bb.org-overlays"
@@ -180,7 +160,6 @@ install_git_repos () {
         cp -v ./tools/beaglebone-universal-io/config-pin /usr/local/bin/
         make clean
 	fi
-
 
     git_repo="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/ "
     git_target_dir="/opt/source/bb.org-dtc"
@@ -197,7 +176,6 @@ install_git_repos () {
         make clean
 	fi
 
-
     git_repo="https://github.com/RobertCNelson/dtb-rebuilder.git"
     git_target_dir="/opt/source/dtb-rebuilder"
     git_branch="4.14-ti"
@@ -210,7 +188,6 @@ install_git_repos () {
         make install
         make clean
 	fi
-
 
     git_repo="https://github.com/mattgodbolt/seasocks.git"
     git_target_dir="/opt/source/seasocks"
@@ -229,38 +206,20 @@ install_git_repos () {
         ldconfig
 	fi
 
-
     git_repo="https://github.com/BelaPlatform/rtdm_pruss_irq"
     git_target_dir="/opt/source/rtdm_pruss_irq"
     git_branch="master"
     git_clone_branch
-
 
     git_repo="https://github.com/giuliomoro/checkinstall"
     git_target_dir="/opt/source/checkinstall"
     git_branch="master"
     git_clone_branch
 
-
     git_repo="https://github.com/giuliomoro/hvcc"
     git_target_dir="/opt/source/hvcc"
     git_branch="master-bela"
     git_clone_branch
-	
-    git_repo="https://github.com/beagleboard/bb.org-overlays"
-    git_target_dir="/opt/source/bb.org-overlays"
-    git_clone
-
-	git_repo="https://github.com/mvduin/bbb-pin-utils"
-	git_target_dir="/opt/source/bbb-pin-utils"
-	git_clone
-	if [ -d /opt/source/bbb-pin-utils/ ] ; then
-		ln -s /opt/source/bbb-pin-utils/show-pins /usr/local/sbin/
-	fi
-
-	git_repo="https://github.com/mvduin/py-uio"
-	git_target_dir="/opt/source/py-uio"
-	git_clone
 
 	git_repo="https://github.com/mvduin/overlay-utils"
 	git_target_dir="/opt/source/overlay-utils"


### PR DESCRIPTION
Updated the target/chroot script (bela.io-bullseye.sh) with installation scripts to repos that bela ships and removed the ones that were not required for bela.
- Added installation script commands of am335x-pru-package, prudebug, bb-overlays, bb-dtc, dtb-rebuilder, seasocks 
- xenomai cross-compilation
- Removed the repos (adafruit-beaglebone-io-python, bbb-pin-utils, py-uio, bb.org-overlays) that were not required for Bela

