### PR TITLE
Depend on qemu-system-arm instead of qemu

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -37,7 +37,7 @@ debootstrap_is_installed () {
 				#FIXME: comment out the next line to use QEMU
 				#exit 2
 				dpkg -l | grep qemu-user-static >/dev/null || deb_pkgs="${deb_pkgs}qemu-user-static "
-				dpkg -l | grep $(dpkg --print-architecture) | grep -v "qemu-" | grep qemu >/dev/null || deb_pkgs="${deb_pkgs}qemu "
+				dpkg -l | grep $(dpkg --print-architecture) | grep "qemu-system-arm" >/dev/null || deb_pkgs="${deb_pkgs}qemu-system-arm "
 			fi
 		fi
 


### PR DESCRIPTION
qemu-system-arm is availale on both Ubuntu and Debian, while qemu does
not exist on Debian.

FIxes #203 