### PR TITLE
update to python3 version of hvcc compiler 

### DIFF
--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -61,7 +61,6 @@ deb_include="	\
 	openssh-server	\
 	psmisc	\
 	python3-dev	\
-	python3-flufl.enum	\
 	python3-jinja2	\
 	python3-pip	\
 	python3-setuptools	\
@@ -70,6 +69,7 @@ deb_include="	\
 	screen	\
 	strace	\
 	sudo	\
+	tox	\
 	unzip	\
 	usbutils	\
 	vim	\

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -216,10 +216,15 @@ install_git_repos () {
     git_branch="master"
     git_clone_branch
 
-    git_repo="https://github.com/giuliomoro/hvcc"
+    git_repo="https://github.com/Wasted-Audio/hvcc.git"
     git_target_dir="/opt/source/hvcc"
-    git_branch="master-bela"
+    git_branch="develop"
     git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building hvcc ~~~~"
+        sudo -H pip3 install -e .
+	fi
 
 	git_repo="https://github.com/mvduin/overlay-utils"
 	git_target_dir="/opt/source/overlay-utils"


### PR DESCRIPTION
The exsisting [hvcc](https://github.com/giuliomoro/hvcc) in bela-bullseye chroot script has python2 dependencies of pip2, enum, jinja2 and in bullseye, python2 is gone. So, updated python3 version of hvcc and added dependency package `tox` in bela-bullseye conf and also removed enum package no more it required.