### PR TITLE
some more bela specific changes

### DIFF
--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -21,6 +21,7 @@ deb_include="	\
 	build-essential	\
 	can-utils	\
 	checkinstall	\
+	clang	\
 	cmake	\
 	curl	\
 	device-tree-compiler	\
@@ -50,7 +51,6 @@ deb_include="	\
 	libreadline-dev	\
 	libsndfile1-dev	\
 	libssl-dev	\
-	libstdc++6-10-dbg	\
 	libtool	\
 	libtool-bin	\
 	libx11-dev	\
@@ -70,6 +70,7 @@ deb_include="	\
 	strace	\
 	sudo	\
 	tox	\
+	tree	\
 	unzip	\
 	usbutils	\
 	vim	\
@@ -89,7 +90,6 @@ deb_mirror=""
 ##Some packages fail to install via debootstrap: deb_additional_pkgs="<comma|space>"
 ##
 deb_additional_pkgs="	\
-	clang-3.9	\
 	gdb	\
 	git-core	\
 	net-tools	\

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -132,12 +132,16 @@ repo_rcnee_pkg_list="	\
 	generic-sys-mods	\
 	gt	\
 	libusbgx	\
+	libxenomai-v3.0-dev	\
+	libxenomai1-v3.0	\
 	linux-image-4.14.108-ti-xenomai-bela-r2	\
 	linux-headers-4.14.108-ti-xenomai-bela-r2	\
 	overlayroot	\
 	sancloud-firmware	\
 	systemd-timesyncd	\
 	umtp-responder	\
+	xenomai-v3.0-kernel-source	\
+	xenomai-v3.0-runtime	\
 "
 
 ##

--- a/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
+++ b/configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf
@@ -1,6 +1,6 @@
 ##
 release="11.4"
-image_type="bela-test"
+image_type="bela-bullseye"
 ##
 ##Debootstrap: https://wiki.debian.org/Debootstrap
 ##
@@ -97,17 +97,17 @@ deb_additional_pkgs="	\
 
 ##
 rfs_username="debian"
-rfs_fullname="Beagle User"
+rfs_fullname="Bela User"
 rfs_password="temppwd"
-rfs_hostname="BeagleBoard"
+rfs_hostname="Bela"
 rfs_root_password="root"
 #rfs_default_desktop=""
 #rfs_desktop_background=""
 rfs_default_locale="en_US.UTF-8"
-rfs_etc_dogtag="BeagleBoard.org Debian Bullseye Generic IoT Image"
-rfs_console_banner="Support: https://bbb.io/debian"
+rfs_etc_dogtag="Bela Debian Bullseye Image"
+rfs_console_banner="More info at https://github.com/RobertCNelson/omap-image-builder"
 rfs_console_user_pass="enable"
-rfs_ssh_banner="Support: https://bbb.io/debian"
+rfs_ssh_banner="Built with omap-image-builder"
 rfs_ssh_user_pass="enable"
 rfs_use_systemdnetworkd="enable"
 #rfs_enable_vscode="enable"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -106,9 +106,31 @@ install_git_repos () {
 	fi
 
 	git_repo="https://github.com/BelaPlatform/Bela.git"
-	git_target_dir="/opt/source/Bela"
+	git_target_dir="/root/Bela"
 	git_branch="master"
 	git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Install .deb files ~~~~"
+		cd resources/stretch/deb/
+			dpkg -i *.deb
+			ldconfig
+		cd ${git_target_dir}/
+		echo "~~~~ Installing Bela ~~~~"
+			for DIR in resources/tools/*; do
+				[ -d "$DIR" ] && { make -j${CORES} -C "$DIR" install || exit 1; }
+			done
+
+			make nostartup
+			make idestartup
+
+			mkdir -p /root/Bela/projects
+			cp -rv /root/Bela/IDE/templates/basic /root/Bela/projects/
+			make -j${CORES} all PROJECT=basic AT=
+			make -j${CORES} lib
+			make -j${CORES} -f Makefile.libraries all
+			ldconfig
+	fi
 
 	git_repo="https://github.com/giuliomoro/am335x_pru_package.git"
 	git_target_dir="/opt/source/am335x_pru_package"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -195,11 +195,6 @@ install_git_repos () {
 	git_branch="master"
 	git_clone_branch
 
-	git_repo="https://github.com/giuliomoro/checkinstall"
-	git_target_dir="/opt/source/checkinstall"
-	git_branch="master"
-	git_clone_branch
-
 	git_repo="https://github.com/Wasted-Audio/hvcc.git"
 	git_target_dir="/opt/source/hvcc"
 	git_branch="develop"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -105,6 +105,34 @@ install_git_repos () {
 		make -j${CORES}
 	fi
 
+	git_repo="https://github.com/mattgodbolt/seasocks.git"
+	git_target_dir="/opt/source/seasocks"
+	git_branch="v1.4.4"
+	git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building Seasocks ~~~~"
+			mkdir build
+			cd build
+			cmake .. -DDEFLATE_SUPPORT=OFF -DUNITTESTS=OFF -DSEASOCKS_SHARED=ON
+			make -j${CORES} seasocks
+			/usr/bin/cmake -P cmake_install.cmake
+			cd /root
+			rm -rf /opt/seasocks/build
+			ldconfig
+	fi
+
+	git_repo="https://github.com/giuliomoro/am335x_pru_package.git"
+	git_target_dir="/opt/source/am335x_pru_package"
+	git_branch="master"
+	git_clone_branch
+	if [ -f ${git_target_dir}/.git/config ] ; then
+		cd ${git_target_dir}/
+		echo "~~~~ Building PRU utils ~~~~"
+			make -j${CORES}
+			make install
+	fi
+
 	git_repo="https://github.com/BelaPlatform/Bela.git"
 	git_target_dir="/root/Bela"
 	git_branch="master"
@@ -130,17 +158,6 @@ install_git_repos () {
 			make -j${CORES} lib
 			make -j${CORES} -f Makefile.libraries all
 			ldconfig
-	fi
-
-	git_repo="https://github.com/giuliomoro/am335x_pru_package.git"
-	git_target_dir="/opt/source/am335x_pru_package"
-	git_branch="master"
-	git_clone_branch
-	if [ -f ${git_target_dir}/.git/config ] ; then
-		cd ${git_target_dir}/
-		echo "~~~~ Building PRU utils ~~~~"
-		make -j${CORES}
-		make install
 	fi
 
 	git_repo="https://github.com/giuliomoro/prudebug.git"
@@ -171,23 +188,6 @@ install_git_repos () {
 	make install
 	cp -v ./tools/beaglebone-universal-io/config-pin /usr/local/bin/
 	make clean
-	fi
-
-	git_repo="https://github.com/mattgodbolt/seasocks.git"
-	git_target_dir="/opt/source/seasocks"
-	git_branch="v1.4.4"
-	git_clone_branch
-	if [ -f ${git_target_dir}/.git/config ] ; then
-		cd ${git_target_dir}/
-		echo "~~~~ Building Seasocks ~~~~"
-		mkdir build
-		cd build
-		cmake .. -DDEFLATE_SUPPORT=OFF -DUNITTESTS=OFF -DSEASOCKS_SHARED=ON
-		make -j${CORES} seasocks
-		/usr/bin/cmake -P cmake_install.cmake
-		cd /root
-		rm -rf /opt/seasocks/build
-		ldconfig
 	fi
 
 	git_repo="https://github.com/BelaPlatform/rtdm_pruss_irq"

--- a/target/chroot/bela.io-bullseye.sh
+++ b/target/chroot/bela.io-bullseye.sh
@@ -97,13 +97,6 @@ install_git_repos () {
 	git_target_dir="/opt/source/xenomai-3"
 	git_branch="stable/v3.0.x"
 	git_clone_branch
-	if [ -f ${git_target_dir}/.git/config ] ; then
-		cd ${git_target_dir}/
-		echo "~~~~ cross-compiling xenomai  ~~~~"
-		scripts/bootstrap
-		./configure --with-core=cobalt --enable-smp --host=arm-linux-gnueabihf --build=arm CFLAGS="-march=armv7-a -mfpu=vfp3"
-		make -j${CORES}
-	fi
 
 	git_repo="https://github.com/mattgodbolt/seasocks.git"
 	git_target_dir="/opt/source/seasocks"


### PR DESCRIPTION
**target/chroot/bela.io-bullseye.sh** 

- Added bela install script along with install required deb packages and also change source installation path to `/root`
- Installed seasocks, am335x_pru_package before building bela so the later does not fail
- Cleaned up checkinstall and also xenomai installation script in chroot in order to install with deb packages 

**configs/bela.io-debian-bullseye-v4.14-ti-xenomai-armhf.conf**

- Added `clang`,`tree`, xenomai-v3.0.13 (l`ibxenomai-v3.0-dev`, `xenomai-v3.0-kernel-source`, `xenomai-v3.0-runtime`, `libxenomai1-v3.0`) and removed `libstdc++6-10-dbg`,`clang-3.9`
- Updated naming and description to bela specific



